### PR TITLE
Implement TurboSHAKE256 XOF

### DIFF
--- a/benches/keccak.rs
+++ b/benches/keccak.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{thread_rng, Rng, RngCore};
-use turboshake::{keccak, turboshake128::TurboShake128};
+use turboshake::{keccak, TurboShake128, TurboShake256};
 
 fn keccak(c: &mut Criterion) {
     let mut rng = thread_rng();
@@ -49,15 +49,12 @@ fn turboshake128<const MLEN: usize, const DLEN: usize>(c: &mut Criterion) {
     c.bench_function(
         &format!("turboshake128/{}/{} (random)", MLEN, DLEN),
         |bench| {
+            let mut msg = vec![0u8; MLEN];
             let mut dig = vec![0u8; DLEN];
+            rng.fill_bytes(&mut msg);
 
             bench.iter_batched(
-                || {
-                    let mut msg = vec![0u8; MLEN];
-                    rng.fill_bytes(&mut msg);
-
-                    msg
-                },
+                || msg.clone(),
                 |msg| {
                     let mut hasher = TurboShake128::new();
                     hasher.absorb(black_box(&msg));
@@ -70,6 +67,46 @@ fn turboshake128<const MLEN: usize, const DLEN: usize>(c: &mut Criterion) {
     );
 }
 
+fn turboshake256<const MLEN: usize, const DLEN: usize>(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    c.bench_function(
+        &format!("turboshake256/{}/{} (cached)", MLEN, DLEN),
+        |bench| {
+            let mut msg = vec![0u8; MLEN];
+            let mut dig = vec![0u8; DLEN];
+            rng.fill_bytes(&mut msg);
+
+            bench.iter(|| {
+                let mut hasher = TurboShake256::new();
+                hasher.absorb(black_box(&msg));
+                hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+                hasher.squeeze(black_box(&mut dig));
+            });
+        },
+    );
+
+    c.bench_function(
+        &format!("turboshake256/{}/{} (random)", MLEN, DLEN),
+        |bench| {
+            let mut msg = vec![0u8; MLEN];
+            let mut dig = vec![0u8; DLEN];
+            rng.fill_bytes(&mut msg);
+
+            bench.iter_batched(
+                || msg.clone(),
+                |msg| {
+                    let mut hasher = TurboShake256::new();
+                    hasher.absorb(black_box(&msg));
+                    hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+                    hasher.squeeze(black_box(&mut dig));
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
 criterion_group!(permutation, keccak);
-criterion_group!(hashing, turboshake128<32, 32>, turboshake128<64, 32>, turboshake128<128, 32>, turboshake128<256, 32>, turboshake128<512, 32>, turboshake128<1024, 32>, turboshake128<2048, 32>, turboshake128<4096, 32>);
+criterion_group!(hashing, turboshake128<32, 32>, turboshake128<64, 32>, turboshake128<128, 32>, turboshake128<256, 32>, turboshake128<512, 32>, turboshake128<1024, 32>, turboshake128<2048, 32>, turboshake128<4096, 32>, turboshake256<32, 32>, turboshake256<64, 32>, turboshake256<128, 32>, turboshake256<256, 32>, turboshake256<512, 32>, turboshake256<1024, 32>, turboshake256<2048, 32>, turboshake256<4096, 32>);
 criterion_main!(permutation, hashing);

--- a/examples/turboshake128.rs
+++ b/examples/turboshake128.rs
@@ -1,5 +1,5 @@
 use rand::{thread_rng, RngCore};
-use turboshake::turboshake128::TurboShake128;
+use turboshake::TurboShake128;
 
 fn main() {
     let mut rng = thread_rng();

--- a/examples/turboshake256.rs
+++ b/examples/turboshake256.rs
@@ -1,5 +1,5 @@
 use rand::{thread_rng, RngCore};
-use turboshake::turboshake256::TurboShake256;
+use turboshake::TurboShake256;
 
 fn main() {
     let mut rng = thread_rng();

--- a/examples/turboshake256.rs
+++ b/examples/turboshake256.rs
@@ -1,0 +1,23 @@
+use rand::{thread_rng, RngCore};
+use turboshake::turboshake256::TurboShake256;
+
+fn main() {
+    let mut rng = thread_rng();
+
+    let mlen = 64;
+    let mut msg = vec![0u8; mlen];
+    rng.fill_bytes(&mut msg);
+
+    let dlen = 32;
+    let mut dig = vec![0u8; dlen];
+
+    let mut hasher = TurboShake256::new();
+    hasher.absorb(&msg[..mlen / 2]);
+    hasher.absorb(&msg[mlen / 2..]);
+    hasher.finalize::<{ TurboShake256::DEFAULT_DOMAIN_SEPARATOR }>();
+    hasher.squeeze(&mut dig[..dlen / 2]);
+    hasher.squeeze(&mut dig[dlen / 2..]);
+
+    println!("Message: {}", hex::encode(&msg));
+    println!("Digest: {}", hex::encode(&dig));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod keccak;
 mod sponge;
-pub mod turboshake128;
-pub mod turboshake256;
+mod turboshake128;
+mod turboshake256;
+
+pub use turboshake128::TurboShake128;
+pub use turboshake256::TurboShake256;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod keccak;
+mod sponge;
 pub mod turboshake128;
 pub mod turboshake256;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod keccak;
 pub mod turboshake128;
+pub mod turboshake256;

--- a/src/sponge.rs
+++ b/src/sponge.rs
@@ -8,6 +8,7 @@ use std::cmp;
 /// - c i.e. capacity can be either of 256 or 512 -bits.
 /// - Rate portion will have bitwidth of 1600 - c.
 /// - `offset` will live in 0 <= offset < RATE_BYTES.
+#[inline(always)]
 pub fn absorb<const RATE_BYTES: usize, const RATE_WORDS: usize>(
     state: &mut [u64; 25],
     offset: &mut usize,
@@ -68,6 +69,7 @@ pub fn absorb<const RATE_BYTES: usize, const RATE_WORDS: usize>(
 /// - c i.e. capacity can be either of 256 or 512 -bits.
 /// - Rate portion will have bitwidth of 1600 - c.
 /// - `offset` will live in 0 <= offset < RATE_BYTES.
+#[inline(always)]
 pub fn finalize<const RATE_BYTES: usize, const RATE_WORDS: usize, const D: u8>(
     state: &mut [u64; 25],
     offset: &mut usize,
@@ -92,6 +94,7 @@ pub fn finalize<const RATE_BYTES: usize, const RATE_WORDS: usize, const D: u8>(
 /// - Rate portion will have bitwidth of 1600 - c.
 /// - `readable` denotes how many bytes can be squeezed without permutating the sponge state.
 /// - When `readable` becomes 0, state needs to be permutated again, after which RATE_BYTES can be squeezed.
+#[inline(always)]
 pub fn squeeze<const RATE_BYTES: usize, const RATE_WORDS: usize>(
     state: &mut [u64; 25],
     readable: &mut usize,

--- a/src/sponge.rs
+++ b/src/sponge.rs
@@ -1,0 +1,62 @@
+use crate::keccak;
+
+/// Given N -bytes message, this routine consumes it into Keccak\[c\] permutation state s.t.
+/// offset ( second parameter ) denotes how many bytes are already consumed into rate portion
+/// of the state.
+///
+/// - c i.e. capacity can be either of 256 or 512 -bits.
+/// - Rate portion will have bitwidth of 1600 - c.
+/// - offset will live in 0 <= offset < RATE_BYTES.
+pub fn absorb<const RATE_BYTES: usize, const RATE_WORDS: usize>(
+    state: &mut [u64; 25],
+    offset: &mut usize,
+    msg: &[u8],
+) {
+    let mlen = msg.len();
+
+    let mut blk_bytes = [0u8; RATE_BYTES];
+
+    let blk_cnt = (*offset + mlen) / RATE_BYTES;
+    let till = blk_cnt * RATE_BYTES;
+    let mut moff = 0;
+
+    while moff < till {
+        let byte_cnt = RATE_BYTES - *offset;
+
+        blk_bytes.fill(0u8);
+        blk_bytes[*offset..].copy_from_slice(&msg[moff..(moff + byte_cnt)]);
+
+        for i in 0..RATE_WORDS {
+            let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+            state[i] ^= word;
+        }
+
+        moff += RATE_BYTES - *offset;
+        *offset += RATE_BYTES - *offset;
+
+        keccak::permute(state);
+        *offset = 0;
+    }
+
+    let rm_bytes = mlen - moff;
+
+    let src_frm = moff;
+    let src_to = src_frm + rm_bytes;
+    let dst_frm = *offset;
+    let dst_to = dst_frm + rm_bytes;
+
+    blk_bytes.fill(0u8);
+    blk_bytes[dst_frm..dst_to].copy_from_slice(&msg[src_frm..src_to]);
+
+    for i in 0..RATE_WORDS {
+        let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+        state[i] ^= word;
+    }
+
+    *offset += rm_bytes;
+
+    if *offset == RATE_BYTES {
+        keccak::permute(state);
+        *offset = 0;
+    }
+}

--- a/src/turboshake128.rs
+++ b/src/turboshake128.rs
@@ -98,27 +98,10 @@ impl TurboShake128 {
             return;
         }
 
-        let olen = out.len();
-        let mut rate = [0u8; Self::RATE_BYTES];
-        let mut off = 0;
-
-        while off < olen {
-            let read = cmp::min(self.squeezable, olen - off);
-            let soff = Self::RATE_BYTES - self.squeezable;
-
-            for i in 0..Self::RATE_WORDS {
-                rate[i * 8..(i + 1) * 8].copy_from_slice(&self.state[i].to_le_bytes());
-            }
-
-            out[off..(off + read)].copy_from_slice(&rate[soff..(soff + read)]);
-
-            self.squeezable -= read;
-            off += read;
-
-            if self.squeezable == 0 {
-                keccak::permute(&mut self.state);
-                self.squeezable = Self::RATE_BYTES;
-            }
-        }
+        sponge::squeeze::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(
+            &mut self.state,
+            &mut self.squeezable,
+            out,
+        );
     }
 }

--- a/src/turboshake128.rs
+++ b/src/turboshake128.rs
@@ -24,6 +24,7 @@ impl TurboShake128 {
     /// Create a new instance of TurboSHAKE128 Extendable Output Function (XOF), into
     /// which arbitrary number of message bytes can be absorbed and arbitrary many bytes
     /// can be squeezed out.
+    #[inline(always)]
     pub fn new() -> Self {
         Self {
             state: [0u64; 25],
@@ -40,6 +41,7 @@ impl TurboShake128 {
     /// similar name ). Once finalized, calling this routine again doesn't do anything.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake128.hpp#L43-L130
+    #[inline(always)]
     pub fn absorb(&mut self, msg: &[u8]) {
         if self.is_ready == usize::MAX {
             return;
@@ -64,6 +66,7 @@ impl TurboShake128 {
     /// Consider using D = 0x1f, if you don't need multiple instances of TurboSHAKE128 XOF.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake128.hpp#L132-L192
+    #[inline(always)]
     pub fn finalize<const D: u8>(&mut self) {
         // See top of page 2 of https://ia.cr/2023/342
         debug_assert!(D >= 0x01 && D <= 0x7f);
@@ -92,6 +95,7 @@ impl TurboShake128 {
     /// it can't squeeze anything out.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake128.hpp#L194-L238
+    #[inline(always)]
     pub fn squeeze(&mut self, out: &mut [u8]) {
         if self.is_ready != usize::MAX {
             return;

--- a/src/turboshake128.rs
+++ b/src/turboshake128.rs
@@ -1,5 +1,4 @@
-use crate::{keccak, sponge};
-use std::cmp;
+use crate::sponge;
 
 /// TurboSHAKE128 Extendable Output Function (XOF)
 ///

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -1,5 +1,4 @@
-use crate::{keccak, sponge};
-use std::cmp;
+use crate::sponge;
 
 /// TurboSHAKE256 Extendable Output Function (XOF)
 ///

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -24,6 +24,7 @@ impl TurboShake256 {
     /// Create a new instance of TurboSHAKE256 Extendable Output Function (XOF), into
     /// which arbitrary number of message bytes can be absorbed and arbitrary many bytes
     /// can be squeezed out.
+    #[inline(always)]
     pub fn new() -> Self {
         Self {
             state: [0u64; 25],
@@ -40,6 +41,7 @@ impl TurboShake256 {
     /// similar name ). Once finalized, calling this routine again doesn't do anything.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L43-L130
+    #[inline(always)]
     pub fn absorb(&mut self, msg: &[u8]) {
         if self.is_ready == usize::MAX {
             return;
@@ -64,6 +66,7 @@ impl TurboShake256 {
     /// Consider using D = 0x1f, if you don't need multiple instances of TurboSHAKE256 XOF.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L132-L192
+    #[inline(always)]
     pub fn finalize<const D: u8>(&mut self) {
         // See top of page 2 of https://ia.cr/2023/342
         debug_assert!(D >= 0x01 && D <= 0x7f);
@@ -92,6 +95,7 @@ impl TurboShake256 {
     /// it can't squeeze anything out.
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L194-L237
+    #[inline(always)]
     pub fn squeeze(&mut self, out: &mut [u8]) {
         if self.is_ready != usize::MAX {
             return;

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -1,0 +1,173 @@
+use crate::keccak;
+use std::cmp;
+
+/// TurboSHAKE256 Extendable Output Function (XOF)
+///
+/// See section 1 of TurboSHAKE specification https://ia.cr/2023/342
+#[derive(Copy, Clone)]
+pub struct TurboShake256 {
+    state: [u64; 25],
+    offset: usize,
+    is_ready: usize,
+    squeezable: usize,
+}
+
+impl TurboShake256 {
+    /// If you don't need multiple instances of TurboSHAKE256, feel free to pass
+    /// this as domain seperator constant, during finalization.
+    pub const DEFAULT_DOMAIN_SEPARATOR: u8 = 0x1f;
+
+    const CAPACITY_BITS: usize = 512;
+    const RATE_BITS: usize = 1600 - Self::CAPACITY_BITS;
+    const RATE_BYTES: usize = Self::RATE_BITS / 8;
+    const RATE_WORDS: usize = Self::RATE_BYTES / 8;
+
+    /// Create a new instance of TurboSHAKE256 Extendable Output Function (XOF), into
+    /// which arbitrary number of message bytes can be absorbed and arbitrary many bytes
+    /// can be squeezed out.
+    pub fn new() -> Self {
+        Self {
+            state: [0u64; 25],
+            offset: 0,
+            is_ready: usize::MIN,
+            squeezable: 0,
+        }
+    }
+
+    /// Given N -bytes input message, this routine consumes those into Keccak\[512\] sponge state
+    ///
+    /// Note, this routine can be called arbitrary number of times, each time with arbitrary
+    /// bytes of input message, until Keccak\[512\] state is finalized ( by calling routine with
+    /// similar name ). Once finalized, calling this routine again doesn't do anything.
+    ///
+    /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L43-L130
+    pub fn absorb(&mut self, msg: &[u8]) {
+        if self.is_ready == usize::MAX {
+            return;
+        }
+
+        let mlen = msg.len();
+
+        let mut blk_bytes = [0u8; Self::RATE_BYTES];
+
+        let blk_cnt = (self.offset + mlen) / Self::RATE_BYTES;
+        let till = blk_cnt * Self::RATE_BYTES;
+        let mut moff = 0;
+
+        while moff < till {
+            let byte_cnt = Self::RATE_BYTES - self.offset;
+
+            blk_bytes.fill(0u8);
+            blk_bytes[self.offset..].copy_from_slice(&msg[moff..(moff + byte_cnt)]);
+
+            for i in 0..Self::RATE_WORDS {
+                let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+                self.state[i] ^= word;
+            }
+
+            moff += Self::RATE_BYTES - self.offset;
+            self.offset += Self::RATE_BYTES - self.offset;
+
+            keccak::permute(&mut self.state);
+            self.offset = 0;
+        }
+
+        let rm_bytes = mlen - moff;
+
+        let src_frm = moff;
+        let src_to = src_frm + rm_bytes;
+        let dst_frm = self.offset;
+        let dst_to = dst_frm + rm_bytes;
+
+        blk_bytes.fill(0u8);
+        blk_bytes[dst_frm..dst_to].copy_from_slice(&msg[src_frm..src_to]);
+
+        for i in 0..Self::RATE_WORDS {
+            let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+            self.state[i] ^= word;
+        }
+
+        self.offset += rm_bytes;
+
+        if self.offset == Self::RATE_BYTES {
+            keccak::permute(&mut self.state);
+            self.offset = 0;
+        }
+    }
+
+    /// After consuming N -bytes ( by invoking absorb routine arbitrary many times,
+    /// each time with arbitrary input bytes ), this routine is invoked when no more
+    /// input bytes remaining to be consumed into Keccak\[512\] sponge state.
+    ///
+    /// Note, once this routine is called, calling absorb() or finalize() again, on same
+    /// TurboSHAKE256 object doesn't do anything. After finalization, one might wish to
+    /// read arbitrary many bytes by squeezing sponge, which is done by calling squeeze()
+    /// function, as many times required.
+    ///
+    /// Consider using D = 0x1f, if you don't need multiple instances of TurboSHAKE256 XOF.
+    ///
+    /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L132-L192
+    pub fn finalize<const D: u8>(&mut self) {
+        if self.is_ready == usize::MAX {
+            return;
+        }
+
+        // See top of page 2 of https://ia.cr/2023/342
+        debug_assert!(D >= 0x01 && D <= 0x7f);
+
+        let mut blk_bytes = [0u8; Self::RATE_BYTES];
+        blk_bytes[self.offset] = D;
+        blk_bytes[Self::RATE_BYTES - 1] ^= 0x80;
+
+        for i in 0..Self::RATE_WORDS {
+            let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
+            self.state[i] ^= word;
+        }
+
+        keccak::permute(&mut self.state);
+
+        self.offset = 0;
+        self.is_ready = usize::MAX;
+        self.squeezable = Self::RATE_BYTES;
+    }
+
+    /// Given that N -bytes input message is already absorbed into sponge state, this
+    /// routine is used for squeezing M -bytes out of consumable part of sponge state
+    /// ( i.e. rate portion of the state ).
+    ///
+    /// Note, this routine can be called arbitrary number of times, for squeezing arbitrary
+    /// number of bytes from sponge Keccak\[512\].
+    ///
+    /// Make sure you absorb message bytes first, then only call this function, otherwise
+    /// it can't squeeze anything out.
+    ///
+    /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L194-L237
+    pub fn squeeze(&mut self, out: &mut [u8]) {
+        if self.is_ready != usize::MAX {
+            return;
+        }
+
+        let olen = out.len();
+        let mut rate = [0u8; Self::RATE_BYTES];
+        let mut off = 0;
+
+        while off < olen {
+            let read = cmp::min(self.squeezable, olen - off);
+            let soff = Self::RATE_BYTES - self.squeezable;
+
+            for i in 0..Self::RATE_WORDS {
+                rate[i * 8..(i + 1) * 8].copy_from_slice(&self.state[i].to_le_bytes());
+            }
+
+            out[off..(off + read)].copy_from_slice(&rate[soff..(soff + read)]);
+
+            self.squeezable -= read;
+            off += read;
+
+            if self.squeezable == 0 {
+                keccak::permute(&mut self.state);
+                self.squeezable = Self::RATE_BYTES;
+            }
+        }
+    }
+}

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -66,25 +66,18 @@ impl TurboShake256 {
     ///
     /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/shake256.hpp#L132-L192
     pub fn finalize<const D: u8>(&mut self) {
+        // See top of page 2 of https://ia.cr/2023/342
+        debug_assert!(D >= 0x01 && D <= 0x7f);
+
         if self.is_ready == usize::MAX {
             return;
         }
 
-        // See top of page 2 of https://ia.cr/2023/342
-        debug_assert!(D >= 0x01 && D <= 0x7f);
+        sponge::finalize::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }, { D }>(
+            &mut self.state,
+            &mut self.offset,
+        );
 
-        let mut blk_bytes = [0u8; Self::RATE_BYTES];
-        blk_bytes[self.offset] = D;
-        blk_bytes[Self::RATE_BYTES - 1] ^= 0x80;
-
-        for i in 0..Self::RATE_WORDS {
-            let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
-            self.state[i] ^= word;
-        }
-
-        keccak::permute(&mut self.state);
-
-        self.offset = 0;
         self.is_ready = usize::MAX;
         self.squeezable = Self::RATE_BYTES;
     }

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -98,27 +98,10 @@ impl TurboShake256 {
             return;
         }
 
-        let olen = out.len();
-        let mut rate = [0u8; Self::RATE_BYTES];
-        let mut off = 0;
-
-        while off < olen {
-            let read = cmp::min(self.squeezable, olen - off);
-            let soff = Self::RATE_BYTES - self.squeezable;
-
-            for i in 0..Self::RATE_WORDS {
-                rate[i * 8..(i + 1) * 8].copy_from_slice(&self.state[i].to_le_bytes());
-            }
-
-            out[off..(off + read)].copy_from_slice(&rate[soff..(soff + read)]);
-
-            self.squeezable -= read;
-            off += read;
-
-            if self.squeezable == 0 {
-                keccak::permute(&mut self.state);
-                self.squeezable = Self::RATE_BYTES;
-            }
-        }
+        sponge::squeeze::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(
+            &mut self.state,
+            &mut self.squeezable,
+            out,
+        );
     }
 }

--- a/src/turboshake256.rs
+++ b/src/turboshake256.rs
@@ -1,4 +1,4 @@
-use crate::keccak;
+use crate::{keccak, sponge};
 use std::cmp;
 
 /// TurboSHAKE256 Extendable Output Function (XOF)
@@ -46,53 +46,11 @@ impl TurboShake256 {
             return;
         }
 
-        let mlen = msg.len();
-
-        let mut blk_bytes = [0u8; Self::RATE_BYTES];
-
-        let blk_cnt = (self.offset + mlen) / Self::RATE_BYTES;
-        let till = blk_cnt * Self::RATE_BYTES;
-        let mut moff = 0;
-
-        while moff < till {
-            let byte_cnt = Self::RATE_BYTES - self.offset;
-
-            blk_bytes.fill(0u8);
-            blk_bytes[self.offset..].copy_from_slice(&msg[moff..(moff + byte_cnt)]);
-
-            for i in 0..Self::RATE_WORDS {
-                let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
-                self.state[i] ^= word;
-            }
-
-            moff += Self::RATE_BYTES - self.offset;
-            self.offset += Self::RATE_BYTES - self.offset;
-
-            keccak::permute(&mut self.state);
-            self.offset = 0;
-        }
-
-        let rm_bytes = mlen - moff;
-
-        let src_frm = moff;
-        let src_to = src_frm + rm_bytes;
-        let dst_frm = self.offset;
-        let dst_to = dst_frm + rm_bytes;
-
-        blk_bytes.fill(0u8);
-        blk_bytes[dst_frm..dst_to].copy_from_slice(&msg[src_frm..src_to]);
-
-        for i in 0..Self::RATE_WORDS {
-            let word = u64::from_le_bytes(blk_bytes[i * 8..(i + 1) * 8].try_into().unwrap());
-            self.state[i] ^= word;
-        }
-
-        self.offset += rm_bytes;
-
-        if self.offset == Self::RATE_BYTES {
-            keccak::permute(&mut self.state);
-            self.offset = 0;
-        }
+        sponge::absorb::<{ Self::RATE_BYTES }, { Self::RATE_WORDS }>(
+            &mut self.state,
+            &mut self.offset,
+            msg,
+        );
     }
 
     /// After consuming N -bytes ( by invoking absorb routine arbitrary many times,


### PR DESCRIPTION
- [x] Add TurboSHAKE256 XOF API
- [x] Reduce code duplication by seperating sponge functionalities
- [x] Benchmark TurboSHAKE256 implementation for various different input sizes 

Issue `cargo bench turboshake256` for benchmarking 

```bash
turboshake256/32/32 (cached)
                        time:   [473.74 ns 474.87 ns 476.16 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

turboshake256/32/32 (random)
                        time:   [515.65 ns 517.48 ns 519.54 ns]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

turboshake256/64/32 (cached)
                        time:   [474.51 ns 475.64 ns 476.79 ns]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

turboshake256/64/32 (random)
                        time:   [520.39 ns 522.36 ns 524.58 ns]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

turboshake256/128/32 (cached)
                        time:   [474.09 ns 475.28 ns 476.63 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

turboshake256/128/32 (random)
                        time:   [531.96 ns 534.22 ns 536.65 ns]
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe

turboshake256/256/32 (cached)
                        time:   [935.44 ns 937.38 ns 939.45 ns]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  6 (6.00%) high mild
  3 (3.00%) high severe

turboshake256/256/32 (random)
                        time:   [1.0117 µs 1.0160 µs 1.0203 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

turboshake256/512/32 (cached)
                        time:   [1.8632 µs 1.8668 µs 1.8707 µs]
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

turboshake256/512/32 (random)
                        time:   [2.0055 µs 2.0174 µs 2.0286 µs]

turboshake256/1024/32 (cached)
                        time:   [3.7099 µs 3.7180 µs 3.7268 µs]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe

turboshake256/1024/32 (random)
                        time:   [3.7826 µs 3.8044 µs 3.8283 µs]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

turboshake256/2048/32 (cached)
                        time:   [7.4063 µs 7.4222 µs 7.4394 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

turboshake256/2048/32 (random)
                        time:   [7.5482 µs 7.5866 µs 7.6289 µs]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

turboshake256/4096/32 (cached)
                        time:   [14.339 µs 14.372 µs 14.409 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

turboshake256/4096/32 (random)
                        time:   [14.415 µs 14.583 µs 14.857 µs]
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
```