### PR TITLE
Update Benchmark Code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turboshake"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Anjan Roy <hello@itzmeanjan.in>"]
 description = "A family of extendable output functions based on keccak-p[1600, 12] permutation"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cargo test --lib
 
 ## Benchmarking
 
-Issue following command for benchmarking round-reduced Keccak-p[1600, 12] permutation and TurboSHAKE{128, 256} XOF ( for various input sizes ). Note, squeezed output size is kept constant at 32 -bytes.
+Issue following command for benchmarking round-reduced Keccak-p[1600, 12] permutation and TurboSHAKE{128, 256} XOF ( for various input sizes ). Note, squeezed output size ( from the XOF ) is kept constant at 32 -bytes.
 
 ```bash
 RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench
@@ -36,205 +36,218 @@ RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench
 ### On **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**
 
 ```bash
-keccak-p[1600, 12] (cached)
-                        time:   [170.97 ns 171.45 ns 172.03 ns]
-Found 11 outliers among 100 measurements (11.00%)
-  6 (6.00%) high mild
-  5 (5.00%) high severe
-
-keccak-p[1600, 12] (random)
-                        time:   [186.23 ns 187.54 ns 188.88 ns]
-Found 8 outliers among 100 measurements (8.00%)
-  7 (7.00%) high mild
-  1 (1.00%) high severe
-
-     Running benches/turboshake.rs (target/release/deps/turboshake-ee40f9eb0651fba3)
-turboshake128/32/32 (cached)
-                        time:   [193.60 ns 194.11 ns 194.67 ns]
-Found 9 outliers among 100 measurements (9.00%)
-  5 (5.00%) high mild
-  4 (4.00%) high severe
-
-turboshake128/32/32 (random)
-                        time:   [226.03 ns 226.81 ns 227.69 ns]
+keccak/keccak-p[1600, 12] (cached)
+                        time:   [171.08 ns 171.72 ns 172.48 ns]
+                        thrpt:  [1.0799 GiB/s 1.0847 GiB/s 1.0888 GiB/s]
 Found 7 outliers among 100 measurements (7.00%)
   1 (1.00%) high mild
   6 (6.00%) high severe
-
-turboshake128/64/32 (cached)
-                        time:   [194.15 ns 194.94 ns 195.99 ns]
-Found 12 outliers among 100 measurements (12.00%)
-  7 (7.00%) high mild
-  5 (5.00%) high severe
-
-turboshake128/64/32 (random)
-                        time:   [233.17 ns 234.13 ns 235.16 ns]
-Found 5 outliers among 100 measurements (5.00%)
-  2 (2.00%) high mild
+keccak/keccak-p[1600, 12] (random)
+                        time:   [188.03 ns 189.51 ns 191.10 ns]
+                        thrpt:  [998.07 MiB/s 1006.5 MiB/s 1014.4 MiB/s]
+Found 7 outliers among 100 measurements (7.00%)
+  4 (4.00%) high mild
   3 (3.00%) high severe
 
-turboshake128/128/32 (cached)
-                        time:   [195.02 ns 195.69 ns 196.41 ns]
-Found 4 outliers among 100 measurements (4.00%)
-  2 (2.00%) high mild
-  2 (2.00%) high severe
+turboshake128/32/32 (cached)
+                        time:   [194.03 ns 194.42 ns 194.84 ns]
+                        thrpt:  [156.63 MiB/s 156.97 MiB/s 157.28 MiB/s]
+Found 11 outliers among 100 measurements (11.00%)
+  6 (6.00%) high mild
+  5 (5.00%) high severe
+turboshake128/32/32 (random)
+                        time:   [227.81 ns 228.51 ns 229.27 ns]
+                        thrpt:  [133.11 MiB/s 133.55 MiB/s 133.96 MiB/s]
+Found 5 outliers among 100 measurements (5.00%)
+  1 (1.00%) high mild
+  4 (4.00%) high severe
 
-turboshake128/128/32 (random)
-                        time:   [245.22 ns 246.58 ns 248.05 ns]
+turboshake128/64/32 (cached)
+                        time:   [194.75 ns 195.23 ns 195.72 ns]
+                        thrpt:  [311.85 MiB/s 312.64 MiB/s 313.40 MiB/s]
+Found 9 outliers among 100 measurements (9.00%)
+  7 (7.00%) high mild
+  2 (2.00%) high severe
+turboshake128/64/32 (random)
+                        time:   [234.68 ns 235.94 ns 237.31 ns]
+                        thrpt:  [257.20 MiB/s 258.69 MiB/s 260.08 MiB/s]
 Found 5 outliers among 100 measurements (5.00%)
   4 (4.00%) high mild
+  1 (1.00%) high severe
+
+turboshake128/128/32 (cached)
+                        time:   [195.89 ns 198.55 ns 202.60 ns]
+                        thrpt:  [602.51 MiB/s 614.81 MiB/s 623.16 MiB/s]
+Found 14 outliers among 100 measurements (14.00%)
+  8 (8.00%) high mild
+  6 (6.00%) high severe
+turboshake128/128/32 (random)
+                        time:   [247.96 ns 249.38 ns 250.89 ns]
+                        thrpt:  [486.55 MiB/s 489.50 MiB/s 492.31 MiB/s]
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
   1 (1.00%) high severe
 
 turboshake128/256/32 (cached)
-                        time:   [371.44 ns 372.54 ns 373.78 ns]
-Found 7 outliers among 100 measurements (7.00%)
-  2 (2.00%) high mild
+                        time:   [371.50 ns 376.57 ns 383.07 ns]
+                        thrpt:  [637.33 MiB/s 648.33 MiB/s 657.18 MiB/s]
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) high mild
   5 (5.00%) high severe
-
 turboshake128/256/32 (random)
-                        time:   [451.83 ns 454.02 ns 456.40 ns]
-Found 8 outliers among 100 measurements (8.00%)
+                        time:   [459.31 ns 462.15 ns 464.75 ns]
+                        thrpt:  [525.32 MiB/s 528.27 MiB/s 531.54 MiB/s]
+Found 3 outliers among 100 measurements (3.00%)
   3 (3.00%) high mild
-  5 (5.00%) high severe
 
 turboshake128/512/32 (cached)
-                        time:   [721.75 ns 724.00 ns 726.39 ns]
+                        time:   [723.39 ns 726.10 ns 729.41 ns]
+                        thrpt:  [669.42 MiB/s 672.47 MiB/s 674.99 MiB/s]
+Found 9 outliers among 100 measurements (9.00%)
+  5 (5.00%) high mild
+  4 (4.00%) high severe
+turboshake128/512/32 (random)
+                        time:   [879.38 ns 890.55 ns 901.22 ns]
+                        thrpt:  [541.80 MiB/s 548.29 MiB/s 555.26 MiB/s]
+
+turboshake128/1024/32 (cached)
+                        time:   [1.2460 µs 1.2493 µs 1.2530 µs]
+                        thrpt:  [779.37 MiB/s 781.69 MiB/s 783.75 MiB/s]
+Found 7 outliers among 100 measurements (7.00%)
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+turboshake128/1024/32 (random)
+                        time:   [1.3155 µs 1.3219 µs 1.3286 µs]
+                        thrpt:  [735.03 MiB/s 738.78 MiB/s 742.33 MiB/s]
+Found 8 outliers among 100 measurements (8.00%)
+  5 (5.00%) high mild
+  3 (3.00%) high severe
+
+turboshake128/2048/32 (cached)
+                        time:   [2.3084 µs 2.3145 µs 2.3216 µs]
+                        thrpt:  [841.30 MiB/s 843.86 MiB/s 846.08 MiB/s]
 Found 7 outliers among 100 measurements (7.00%)
   4 (4.00%) high mild
   3 (3.00%) high severe
-
-turboshake128/512/32 (random)
-                        time:   [897.06 ns 909.89 ns 923.12 ns]
-Found 1 outliers among 100 measurements (1.00%)
-  1 (1.00%) high mild
-
-turboshake128/1024/32 (cached)
-                        time:   [1.2600 µs 1.2641 µs 1.2689 µs]
-Found 6 outliers among 100 measurements (6.00%)
-  4 (4.00%) high mild
-  2 (2.00%) high severe
-
-turboshake128/1024/32 (random)
-                        time:   [1.3228 µs 1.3311 µs 1.3405 µs]
-Found 10 outliers among 100 measurements (10.00%)
-  5 (5.00%) high mild
-  5 (5.00%) high severe
-
-turboshake128/2048/32 (cached)
-                        time:   [2.3093 µs 2.3156 µs 2.3222 µs]
-Found 6 outliers among 100 measurements (6.00%)
-  2 (2.00%) high mild
-  4 (4.00%) high severe
-
 turboshake128/2048/32 (random)
-                        time:   [2.3835 µs 2.3930 µs 2.4032 µs]
-Found 12 outliers among 100 measurements (12.00%)
-  10 (10.00%) high mild
-  2 (2.00%) high severe
+                        time:   [2.3903 µs 2.3993 µs 2.4087 µs]
+                        thrpt:  [810.86 MiB/s 814.03 MiB/s 817.10 MiB/s]
+Found 5 outliers among 100 measurements (5.00%)
+  2 (2.00%) high mild
+  3 (3.00%) high severe
 
 turboshake128/4096/32 (cached)
-                        time:   [4.4126 µs 4.4259 µs 4.4407 µs]
-Found 8 outliers among 100 measurements (8.00%)
-  4 (4.00%) high mild
-  4 (4.00%) high severe
-
-turboshake128/4096/32 (random)
-                        time:   [4.4995 µs 4.5224 µs 4.5482 µs]
-Found 10 outliers among 100 measurements (10.00%)
-  8 (8.00%) high mild
-  2 (2.00%) high severe
-
-turboshake256/32/32 (cached)
-                        time:   [190.16 ns 190.61 ns 191.08 ns]
-Found 5 outliers among 100 measurements (5.00%)
-  4 (4.00%) high mild
-  1 (1.00%) high severe
-
-turboshake256/32/32 (random)
-                        time:   [222.62 ns 223.58 ns 224.62 ns]
+                        time:   [4.4181 µs 4.4307 µs 4.4442 µs]
+                        thrpt:  [878.96 MiB/s 881.62 MiB/s 884.14 MiB/s]
 Found 7 outliers among 100 measurements (7.00%)
   5 (5.00%) high mild
   2 (2.00%) high severe
+turboshake128/4096/32 (random)
+                        time:   [4.6364 µs 4.6615 µs 4.6835 µs]
+                        thrpt:  [834.05 MiB/s 837.99 MiB/s 842.52 MiB/s]
+
+turboshake256/32/32 (cached)
+                        time:   [190.63 ns 191.16 ns 191.75 ns]
+                        thrpt:  [159.15 MiB/s 159.64 MiB/s 160.09 MiB/s]
+Found 8 outliers among 100 measurements (8.00%)
+  4 (4.00%) high mild
+  4 (4.00%) high severe
+turboshake256/32/32 (random)
+                        time:   [223.73 ns 225.53 ns 227.68 ns]
+                        thrpt:  [134.04 MiB/s 135.31 MiB/s 136.40 MiB/s]
+Found 6 outliers among 100 measurements (6.00%)
+  3 (3.00%) high mild
+  3 (3.00%) high severe
 
 turboshake256/64/32 (cached)
-                        time:   [189.81 ns 190.33 ns 190.94 ns]
-Found 9 outliers among 100 measurements (9.00%)
-  7 (7.00%) high mild
-  2 (2.00%) high severe
-
+                        time:   [191.15 ns 191.64 ns 192.17 ns]
+                        thrpt:  [317.61 MiB/s 318.49 MiB/s 319.31 MiB/s]
+Found 7 outliers among 100 measurements (7.00%)
+  4 (4.00%) high mild
+  3 (3.00%) high severe
 turboshake256/64/32 (random)
-                        time:   [228.10 ns 228.91 ns 229.78 ns]
-Found 8 outliers among 100 measurements (8.00%)
-  3 (3.00%) high mild
+                        time:   [228.44 ns 229.55 ns 230.79 ns]
+                        thrpt:  [264.46 MiB/s 265.89 MiB/s 267.19 MiB/s]
+Found 12 outliers among 100 measurements (12.00%)
+  7 (7.00%) high mild
   5 (5.00%) high severe
 
 turboshake256/128/32 (cached)
-                        time:   [191.65 ns 192.49 ns 193.46 ns]
-Found 8 outliers among 100 measurements (8.00%)
-  7 (7.00%) high mild
-  1 (1.00%) high severe
-
-turboshake256/128/32 (random)
-                        time:   [239.42 ns 240.75 ns 242.17 ns]
-Found 5 outliers among 100 measurements (5.00%)
-  1 (1.00%) high mild
-  4 (4.00%) high severe
-
-turboshake256/256/32 (cached)
-                        time:   [364.12 ns 365.34 ns 366.67 ns]
-Found 9 outliers among 100 measurements (9.00%)
-  4 (4.00%) high mild
-  5 (5.00%) high severe
-
-turboshake256/256/32 (random)
-                        time:   [451.02 ns 453.37 ns 455.85 ns]
-Found 6 outliers among 100 measurements (6.00%)
-  4 (4.00%) high mild
-  2 (2.00%) high severe
-
-turboshake256/512/32 (cached)
-                        time:   [708.38 ns 712.26 ns 717.51 ns]
-Found 9 outliers among 100 measurements (9.00%)
-  4 (4.00%) high mild
-  5 (5.00%) high severe
-
-turboshake256/512/32 (random)
-                        time:   [873.98 ns 884.23 ns 894.00 ns]
-
-turboshake256/1024/32 (cached)
-                        time:   [1.3822 µs 1.3854 µs 1.3889 µs]
-Found 10 outliers among 100 measurements (10.00%)
-  6 (6.00%) high mild
-  4 (4.00%) high severe
-
-turboshake256/1024/32 (random)
-                        time:   [1.5439 µs 1.5562 µs 1.5697 µs]
-Found 5 outliers among 100 measurements (5.00%)
-  4 (4.00%) high mild
-  1 (1.00%) high severe
-
-turboshake256/2048/32 (cached)
-                        time:   [2.8448 µs 2.8567 µs 2.8693 µs]
+                        time:   [190.90 ns 191.73 ns 192.76 ns]
+                        thrpt:  [633.28 MiB/s 636.67 MiB/s 639.46 MiB/s]
 Found 5 outliers among 100 measurements (5.00%)
   2 (2.00%) high mild
   3 (3.00%) high severe
+turboshake256/128/32 (random)
+                        time:   [241.36 ns 246.30 ns 252.58 ns]
+                        thrpt:  [483.29 MiB/s 495.61 MiB/s 505.75 MiB/s]
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
 
-turboshake256/2048/32 (random)
-                        time:   [2.9912 µs 3.0048 µs 3.0190 µs]
+turboshake256/256/32 (cached)
+                        time:   [456.61 ns 500.62 ns 552.86 ns]
+                        thrpt:  [441.60 MiB/s 487.68 MiB/s 534.68 MiB/s]
+Found 18 outliers among 100 measurements (18.00%)
+  6 (6.00%) high mild
+  12 (12.00%) high severe
+turboshake256/256/32 (random)
+                        time:   [507.76 ns 549.49 ns 601.73 ns]
+                        thrpt:  [405.73 MiB/s 444.30 MiB/s 480.82 MiB/s]
+Found 14 outliers among 100 measurements (14.00%)
+  4 (4.00%) low mild
+  2 (2.00%) high mild
+  8 (8.00%) high severe
+
+turboshake256/512/32 (cached)
+                        time:   [716.74 ns 719.57 ns 722.80 ns]
+                        thrpt:  [675.54 MiB/s 678.58 MiB/s 681.26 MiB/s]
+Found 11 outliers among 100 measurements (11.00%)
+  9 (9.00%) high mild
+  2 (2.00%) high severe
+turboshake256/512/32 (random)
+                        time:   [884.19 ns 895.35 ns 906.16 ns]
+                        thrpt:  [538.84 MiB/s 545.35 MiB/s 552.23 MiB/s]
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+
+turboshake256/1024/32 (cached)
+                        time:   [1.3902 µs 1.3993 µs 1.4105 µs]
+                        thrpt:  [692.34 MiB/s 697.91 MiB/s 702.47 MiB/s]
 Found 8 outliers among 100 measurements (8.00%)
+  3 (3.00%) high mild
+  5 (5.00%) high severe
+turboshake256/1024/32 (random)
+                        time:   [1.4778 µs 1.4842 µs 1.4915 µs]
+                        thrpt:  [654.75 MiB/s 657.97 MiB/s 660.82 MiB/s]
+Found 7 outliers among 100 measurements (7.00%)
   4 (4.00%) high mild
-  4 (4.00%) high severe
+  3 (3.00%) high severe
 
-turboshake256/4096/32 (cached)
-                        time:   [5.3825 µs 5.4103 µs 5.4438 µs]
+turboshake256/2048/32 (cached)
+                        time:   [2.7661 µs 2.7744 µs 2.7839 µs]
+                        thrpt:  [701.57 MiB/s 703.97 MiB/s 706.09 MiB/s]
 Found 8 outliers among 100 measurements (8.00%)
   6 (6.00%) high mild
   2 (2.00%) high severe
+turboshake256/2048/32 (random)
+                        time:   [2.8918 µs 2.9032 µs 2.9153 µs]
+                        thrpt:  [669.95 MiB/s 672.75 MiB/s 675.40 MiB/s]
+Found 9 outliers among 100 measurements (9.00%)
+  8 (8.00%) high mild
+  1 (1.00%) high severe
 
+turboshake256/4096/32 (cached)
+                        time:   [5.3096 µs 5.3237 µs 5.3394 µs]
+                        thrpt:  [731.59 MiB/s 733.74 MiB/s 735.69 MiB/s]
+Found 11 outliers among 100 measurements (11.00%)
+  5 (5.00%) high mild
+  6 (6.00%) high severe
 turboshake256/4096/32 (random)
-                        time:   [5.5844 µs 5.6091 µs 5.6342 µs]
-Found 8 outliers among 100 measurements (8.00%)
-  6 (6.00%) high mild
+                        time:   [5.5134 µs 5.5296 µs 5.5474 µs]
+                        thrpt:  [704.16 MiB/s 706.43 MiB/s 708.50 MiB/s]
+Found 7 outliers among 100 measurements (7.00%)
+  5 (5.00%) high mild
   2 (2.00%) high severe
 ```
 
@@ -249,7 +262,7 @@ Using TurboSHAKE{128, 256} XOF API is fairly easy
 # either
 turboshake = { git = "https://github.com/itzmeanjan/turboshake" }
 # or
-turboshake = "0.1.1"
+turboshake = "0.1.2"
 ```
 
 2) Create a TurboSHAKE{128, 256} XOF object.

--- a/benches/keccak.rs
+++ b/benches/keccak.rs
@@ -1,18 +1,20 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use rand::{thread_rng, Rng};
 use turboshake::keccak;
 
 fn keccak(c: &mut Criterion) {
     let mut rng = thread_rng();
 
-    c.bench_function("keccak-p[1600, 12] (cached)", |bench| {
+    let mut group = c.benchmark_group("keccak");
+    group.throughput(Throughput::Bytes(200u64)); // size of keccak-p[1600] permutation state
+
+    group.bench_function("keccak-p[1600, 12] (cached)", |bench| {
         let mut state = [0u64; 25];
         rng.fill(&mut state);
 
         bench.iter(|| keccak::permute(black_box(&mut state)))
     });
-
-    c.bench_function("keccak-p[1600, 12] (random)", |bench| {
+    group.bench_function("keccak-p[1600, 12] (random)", |bench| {
         bench.iter_batched(
             || {
                 (0..25)
@@ -25,6 +27,8 @@ fn keccak(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
+
+    group.finish();
 }
 
 criterion_group!(permutation, keccak);

--- a/benches/turboshake.rs
+++ b/benches/turboshake.rs
@@ -1,85 +1,81 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 use rand::{thread_rng, RngCore};
 use turboshake::{TurboShake128, TurboShake256};
 
 fn turboshake128<const MLEN: usize, const DLEN: usize>(c: &mut Criterion) {
     let mut rng = thread_rng();
 
-    c.bench_function(
-        &format!("turboshake128/{}/{} (cached)", MLEN, DLEN),
-        |bench| {
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
-            rng.fill_bytes(&mut msg);
+    let mut group = c.benchmark_group("turboshake128");
+    group.throughput(Throughput::Bytes(MLEN as u64));
 
-            bench.iter(|| {
+    group.bench_function(&format!("{}/{} (cached)", MLEN, DLEN), |bench| {
+        let mut msg = vec![0u8; MLEN];
+        let mut dig = vec![0u8; DLEN];
+        rng.fill_bytes(&mut msg);
+
+        bench.iter(|| {
+            let mut hasher = TurboShake128::new();
+            hasher.absorb(black_box(&msg));
+            hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+            hasher.squeeze(black_box(&mut dig));
+        });
+    });
+    group.bench_function(&format!("{}/{} (random)", MLEN, DLEN), |bench| {
+        let mut msg = vec![0u8; MLEN];
+        let mut dig = vec![0u8; DLEN];
+        rng.fill_bytes(&mut msg);
+
+        bench.iter_batched(
+            || msg.clone(),
+            |msg| {
                 let mut hasher = TurboShake128::new();
                 hasher.absorb(black_box(&msg));
                 hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
                 hasher.squeeze(black_box(&mut dig));
-            });
-        },
-    );
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-    c.bench_function(
-        &format!("turboshake128/{}/{} (random)", MLEN, DLEN),
-        |bench| {
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
-            rng.fill_bytes(&mut msg);
-
-            bench.iter_batched(
-                || msg.clone(),
-                |msg| {
-                    let mut hasher = TurboShake128::new();
-                    hasher.absorb(black_box(&msg));
-                    hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
-                    hasher.squeeze(black_box(&mut dig));
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    group.finish();
 }
 
 fn turboshake256<const MLEN: usize, const DLEN: usize>(c: &mut Criterion) {
     let mut rng = thread_rng();
 
-    c.bench_function(
-        &format!("turboshake256/{}/{} (cached)", MLEN, DLEN),
-        |bench| {
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
-            rng.fill_bytes(&mut msg);
+    let mut group = c.benchmark_group("turboshake256");
+    group.throughput(Throughput::Bytes(MLEN as u64));
 
-            bench.iter(|| {
+    group.bench_function(&format!("{}/{} (cached)", MLEN, DLEN), |bench| {
+        let mut msg = vec![0u8; MLEN];
+        let mut dig = vec![0u8; DLEN];
+        rng.fill_bytes(&mut msg);
+
+        bench.iter(|| {
+            let mut hasher = TurboShake256::new();
+            hasher.absorb(black_box(&msg));
+            hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+            hasher.squeeze(black_box(&mut dig));
+        });
+    });
+    group.bench_function(&format!("{}/{} (random)", MLEN, DLEN), |bench| {
+        let mut msg = vec![0u8; MLEN];
+        let mut dig = vec![0u8; DLEN];
+        rng.fill_bytes(&mut msg);
+
+        bench.iter_batched(
+            || msg.clone(),
+            |msg| {
                 let mut hasher = TurboShake256::new();
                 hasher.absorb(black_box(&msg));
                 hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
                 hasher.squeeze(black_box(&mut dig));
-            });
-        },
-    );
+            },
+            BatchSize::SmallInput,
+        );
+    });
 
-    c.bench_function(
-        &format!("turboshake256/{}/{} (random)", MLEN, DLEN),
-        |bench| {
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
-            rng.fill_bytes(&mut msg);
-
-            bench.iter_batched(
-                || msg.clone(),
-                |msg| {
-                    let mut hasher = TurboShake256::new();
-                    hasher.absorb(black_box(&msg));
-                    hasher.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
-                    hasher.squeeze(black_box(&mut dig));
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+    group.finish();
 }
 
 criterion_group!(hashing, turboshake128<32, 32>, turboshake128<64, 32>, turboshake128<128, 32>, turboshake128<256, 32>, turboshake128<512, 32>, turboshake128<1024, 32>, turboshake128<2048, 32>, turboshake128<4096, 32>, turboshake256<32, 32>, turboshake256<64, 32>, turboshake256<128, 32>, turboshake256<256, 32>, turboshake256<512, 32>, turboshake256<1024, 32>, turboshake256<2048, 32>, turboshake256<4096, 32>);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,12 +3,14 @@ use std::cmp;
 
 /// Generates static byte pattern of length 251, following
 /// https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
+#[allow(dead_code)]
 fn pattern() -> [u8; 251] {
     (0..251).map(|i| i).collect::<Vec<u8>>().try_into().unwrap()
 }
 
 /// Generates bytearray of length n by repeating static byte pattern returned by `pattern()`,
 /// following https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
+#[allow(dead_code)]
 fn ptn(n: usize) -> Vec<u8> {
     let mut res = vec![0; n];
 
@@ -25,6 +27,7 @@ fn ptn(n: usize) -> Vec<u8> {
 /// Given a message M of length n -bytes, absorbs it into TurboSHAKE128 object, while
 /// finalizing it by using domain seperator constant D ( generic constant parameter )
 /// and returning TurboSHAKE128 object, ready to be squeezed.
+#[allow(dead_code)]
 fn turboshake128<const D: u8>(msg: &[u8]) -> TurboShake128 {
     let mut hasher = TurboShake128::new();
     hasher.absorb(msg);
@@ -35,6 +38,7 @@ fn turboshake128<const D: u8>(msg: &[u8]) -> TurboShake128 {
 /// Given a message M of length n -bytes, absorbs it into TurboSHAKE256 object, while
 /// finalizing it by using domain seperator constant D ( generic constant parameter )
 /// and returning TurboSHAKE256 object, ready to be squeezed.
+#[allow(dead_code)]
 fn turboshake256<const D: u8>(msg: &[u8]) -> TurboShake256 {
     let mut hasher = TurboShake256::new();
     hasher.absorb(msg);


### PR DESCRIPTION
Use criterion for computing throughput of keccak-p[1600, 12] permutation and TurboSHAKE{128, 256} XOF.
