### PR TITLE
Developer friendly features behind `dev` feature-gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turboshake"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Anjan Roy <hello@itzmeanjan.in>"]
 description = "A family of extendable output functions based on keccak-p[1600, 12] permutation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "MIT"
 keywords = ["cryptography", "keccak", "xof", "hashing", "turboshake"]
 categories = ["cryptography"]
 
+[features]
+dev = []
+
 [dependencies]
 crunchy = "0.2.2"
 
@@ -25,6 +28,7 @@ bench = false
 [[bench]]
 name = "keccak"
 harness = false
+required-features = ["dev"]
 
 [[bench]]
 name = "turboshake"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # turboshake
-TurboSHAKE: A Family of e**X**tendable **O**utput **F**unctions based on round reduced Keccak[1600] Permutation
+TurboSHAKE: A Family of e**X**tendable **O**utput **F**unctions based on round reduced ( 12 rounds ) Keccak[1600] Permutation
 
 ## Overview
 
@@ -30,7 +30,11 @@ cargo test --lib
 Issue following command for benchmarking round-reduced Keccak-p[1600, 12] permutation and TurboSHAKE{128, 256} XOF ( for various input sizes ). Note, squeezed output size ( from the XOF ) is kept constant at 32 -bytes.
 
 ```bash
+# if only interested in TurboSHAKE{128, 256} XOF
 RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench
+
+# also benchmarks keccak-p[1600, 12]
+RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench --features dev
 ```
 
 ### On **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**
@@ -262,7 +266,9 @@ Using TurboSHAKE{128, 256} XOF API is fairly easy
 # either
 turboshake = { git = "https://github.com/itzmeanjan/turboshake" }
 # or
-turboshake = "0.1.2"
+turboshake = "0.1.3"
+# or if interested in using underlying keccak-p[1600, 12] and sponge (developer) API
+turboshake = { version = "0.1.3", features = "dev" }
 ```
 
 2) Create a TurboSHAKE{128, 256} XOF object.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
+#[cfg(feature = "dev")]
 pub mod keccak;
+#[cfg(not(feature = "dev"))]
+mod keccak;
+
+#[cfg(feature = "dev")]
+pub mod sponge;
+#[cfg(not(feature = "dev"))]
 mod sponge;
+
 mod tests;
 mod turboshake128;
 mod turboshake256;


### PR DESCRIPTION
Putting keccak-p[1600, 12] permutation and sponge absorb/ finalize/ squeeze related functions behind `dev` feature-gate. You may use those features by adding turboshake as your project dependency 

```toml
[dependencies]
turboshake = { version = "0.1.3", features = ["dev"]}
```

By default, `dev` features are not enabled, meaning you can only use TurboSHAKE{128, 256} XOF API.