### PR TITLE
Fix Absorption Into Keccak Sponge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turboshake"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Anjan Roy <hello@itzmeanjan.in>"]
 description = "A family of extendable output functions based on keccak-p[1600, 12] permutation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ crunchy = "0.2.2"
 rand = "0.8.5"
 hex = "0.4.3"
 criterion = "0.4.0"
+test-case = "3.0.0"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -266,9 +266,9 @@ Using TurboSHAKE{128, 256} XOF API is fairly easy
 # either
 turboshake = { git = "https://github.com/itzmeanjan/turboshake" }
 # or
-turboshake = "0.1.3"
+turboshake = "0.1.4"
 # or if interested in using underlying keccak-p[1600, 12] and sponge (developer) API
-turboshake = { version = "0.1.3", features = "dev" }
+turboshake = { version = "0.1.4", features = "dev" }
 ```
 
 2) Create a TurboSHAKE{128, 256} XOF object.

--- a/src/sponge.rs
+++ b/src/sponge.rs
@@ -14,14 +14,12 @@ pub fn absorb<const RATE_BYTES: usize, const RATE_WORDS: usize>(
     offset: &mut usize,
     msg: &[u8],
 ) {
-    let mlen = msg.len();
     let mut blk_bytes = [0u8; RATE_BYTES];
 
-    let blk_cnt = (*offset + mlen) / RATE_BYTES;
-    let till = blk_cnt * RATE_BYTES;
+    let blk_cnt = (*offset + msg.len()) / RATE_BYTES;
     let mut moff = 0;
 
-    while moff < till {
+    for _ in 0..blk_cnt {
         let byte_cnt = RATE_BYTES - *offset;
 
         blk_bytes.fill(0u8);
@@ -32,14 +30,14 @@ pub fn absorb<const RATE_BYTES: usize, const RATE_WORDS: usize>(
             state[i] ^= word;
         }
 
-        moff += RATE_BYTES - *offset;
-        *offset += RATE_BYTES - *offset;
+        moff += byte_cnt;
+        *offset += byte_cnt;
 
         keccak::permute(state);
         *offset = 0;
     }
 
-    let rm_bytes = mlen - moff;
+    let rm_bytes = msg.len() - moff;
 
     let src_frm = moff;
     let src_to = src_frm + rm_bytes;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -340,9 +340,7 @@ fn test_incremental_ts128_hashing(mlen: usize, dlen: usize) {
     hasher1.squeeze(&mut dig1);
 
     // finally compare if both of them arrive at same digest or not !
-    for i in 0..dlen {
-        assert_eq!(dig0[i], dig1[0]);
-    }
+    assert_eq!(hex::encode(dig0), hex::encode(dig1));
 }
 
 /// Test if both oneshot and incremental hashing API of TurboSHAKE256 produces same result for same input message.
@@ -387,7 +385,5 @@ fn test_incremental_ts256_hashing(mlen: usize, dlen: usize) {
     hasher1.squeeze(&mut dig1);
 
     // finally compare if both of them arrive at same digest or not !
-    for i in 0..dlen {
-        assert_eq!(dig0[i], dig1[0]);
-    }
+    assert_eq!(hex::encode(dig0), hex::encode(dig1));
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,9 @@
+#![cfg(test)]
+
 use crate::{TurboShake128, TurboShake256};
+use rand::{thread_rng, RngCore};
 use std::cmp;
+use test_case::test_case;
 
 /// Generates static byte pattern of length 251, following
 /// https://www.ietf.org/archive/id/draft-irtf-cfrg-kangarootwelve-09.html#name-test-vectors
@@ -292,4 +296,51 @@ fn test_turboshake256() {
         hex::encode(&out),
         "49b38a11204328440c4c40fdaee305629379936d7a31f9474c4f0fb062a2a427"
     );
+}
+
+/// Test if both oneshot and incremental hashing API of TurboSHAKE128 produces same result for same input message.
+///
+/// Adapated from https://github.com/itzmeanjan/ascon/blob/f9ce50dd23b89e073e1f8fe94318d694e9b6770e/include/test/test_incremental_hashing.hpp#L11-L56
+#[test_case(32, 32; "message length = 32B, digest length = 32B")]
+#[test_case(64, 64; "message length = 64B, digest length = 64B")]
+#[test_case(128, 128; "message length = 128B, digest length = 128B")]
+#[test_case(256, 256; "message length = 256B, digest length = 256B")]
+#[test_case(512, 512; "message length = 512B, digest length = 512B")]
+#[test_case(1024, 1024; "message length = 1024B, digest length = 1024B")]
+fn test_incremental_ts128_hashing(mlen: usize, dlen: usize) {
+    // generate random input bytes ( of length mlen )
+    let mut rng = thread_rng();
+    let mut msg = vec![0u8; mlen];
+    rng.fill_bytes(&mut msg);
+
+    // digest computed by oneshot hasher
+    let mut dig0 = vec![0u8; dlen];
+    // digest computed by incremental hasher
+    let mut dig1 = vec![0u8; dlen];
+
+    // oneshot hashing
+    let mut hasher0 = TurboShake128::new();
+    hasher0.absorb(&msg);
+    hasher0.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+    hasher0.squeeze(&mut dig0);
+
+    // incremental hashing
+    let mut hasher1 = TurboShake128::new();
+
+    let mut off = 0;
+    while off < mlen {
+        // because we don't want to be stuck in an infinite loop if msg[off] = 0 !
+        let elen = cmp::min(cmp::max(msg[off] as usize, 1), mlen - off);
+
+        hasher1.absorb(&msg[off..(off + elen)]);
+        off += elen;
+    }
+
+    hasher1.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+    hasher1.squeeze(&mut dig1);
+
+    // finally compare if both of them arrive at same digest or not !
+    for i in 0..dlen {
+        assert_eq!(dig0[i], dig1[0]);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -344,3 +344,50 @@ fn test_incremental_ts128_hashing(mlen: usize, dlen: usize) {
         assert_eq!(dig0[i], dig1[0]);
     }
 }
+
+/// Test if both oneshot and incremental hashing API of TurboSHAKE256 produces same result for same input message.
+///
+/// Adapated from https://github.com/itzmeanjan/ascon/blob/f9ce50dd23b89e073e1f8fe94318d694e9b6770e/include/test/test_incremental_hashing.hpp#L11-L56
+#[test_case(32, 32; "message length = 32B, digest length = 32B")]
+#[test_case(64, 64; "message length = 64B, digest length = 64B")]
+#[test_case(128, 128; "message length = 128B, digest length = 128B")]
+#[test_case(256, 256; "message length = 256B, digest length = 256B")]
+#[test_case(512, 512; "message length = 512B, digest length = 512B")]
+#[test_case(1024, 1024; "message length = 1024B, digest length = 1024B")]
+fn test_incremental_ts256_hashing(mlen: usize, dlen: usize) {
+    // generate random input bytes ( of length mlen )
+    let mut rng = thread_rng();
+    let mut msg = vec![0u8; mlen];
+    rng.fill_bytes(&mut msg);
+
+    // digest computed by oneshot hasher
+    let mut dig0 = vec![0u8; dlen];
+    // digest computed by incremental hasher
+    let mut dig1 = vec![0u8; dlen];
+
+    // oneshot hashing
+    let mut hasher0 = TurboShake256::new();
+    hasher0.absorb(&msg);
+    hasher0.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+    hasher0.squeeze(&mut dig0);
+
+    // incremental hashing
+    let mut hasher1 = TurboShake256::new();
+
+    let mut off = 0;
+    while off < mlen {
+        // because we don't want to be stuck in an infinite loop if msg[off] = 0 !
+        let elen = cmp::min(cmp::max(msg[off] as usize, 1), mlen - off);
+
+        hasher1.absorb(&msg[off..(off + elen)]);
+        off += elen;
+    }
+
+    hasher1.finalize::<{ TurboShake128::DEFAULT_DOMAIN_SEPARATOR }>();
+    hasher1.squeeze(&mut dig1);
+
+    // finally compare if both of them arrive at same digest or not !
+    for i in 0..dlen {
+        assert_eq!(dig0[i], dig1[0]);
+    }
+}


### PR DESCRIPTION
- [x] Add tests for ensuring that both incremental and oneshot hashing ( of TurboSHAKE{128, 256} ) produces same output bytes for same input.
- [x] Update absorb routine so that it behaves correctly ( caught the mistake while working on https://github.com/itzmeanjan/kangarootwelve ).