### PR TITLE
SIMD Parallel 2x Keccak-p[1600, 12] Permutation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography"]
 
 [features]
 dev = []
+simd = []
 
 [dependencies]
 crunchy = "0.2.2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+profile = "minimal"

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -163,6 +163,32 @@ fn rho(state: &mut [u64; 25]) {
     }
 }
 
+/// Keccak-p\[1600, 12\] step mapping function ρ, parallelly applied on two Keccak-p\[1600\]
+/// states, represented using 128 -bit vectors, following algorithm described on section 3.2.2 of SHA3
+/// specification https://dx.doi.org/10.6028/NIST.FIPS.202
+///
+/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
+///
+/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
+///
+/// \[<-----------u64----------> || <-----------u64-------->\]
+///
+/// \[<-------------------------u64x2---------------------->\]
+///
+/// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L177-L190
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn rhox2(state: &mut [u64x2; 25]) {
+    unroll! {
+        for i in 0..25 {
+            let shl = u64x2::splat(ROT[i] as u64);
+            let shr = u64x2::splat((64 - ROT[i]) as u64);
+
+            state[i] = (state[i] << shl) | (state[i] >> shr);
+        }
+    }
+}
+
 /// Keccak-p\[1600, 12\] step mapping function π, see section 3.2.3 of SHA3
 /// specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -103,17 +103,6 @@ fn theta(state: &mut [u64; 25]) {
 /// states, represented using 128 -bit vectors, following algorithm described on section 3.2.1
 /// of SHA3 specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///
-/// Every lane is 128 -bit wide, holding two different Keccak-p\[1600\] lanes, each of
-/// width 64 -bits. Lanes are laid out on registers as shown below.
-///
-/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
-///
-/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
-///
-/// \[<-----------u64----------> || <-----------u64-------->\]
-///
-/// \[<-------------------------u64x2---------------------->\]
-///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L145-L175
 #[cfg(feature = "simd")]
 #[inline(always)]
@@ -170,17 +159,6 @@ fn rho(state: &mut [u64; 25]) {
 /// states, represented using 128 -bit vectors, following algorithm described on section 3.2.2 of SHA3
 /// specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///
-/// Every lane is 128 -bit wide, holding two different Keccak-p\[1600\] lanes, each of
-/// width 64 -bits. Lanes are laid out on registers as shown below.
-///
-/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
-///
-/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
-///
-/// \[<-----------u64----------> || <-----------u64-------->\]
-///
-/// \[<-------------------------u64x2---------------------->\]
-///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L177-L190
 #[cfg(feature = "simd")]
 #[inline(always)]
@@ -232,17 +210,6 @@ fn chi(istate: &[u64; 25], ostate: &mut [u64; 25]) {
 /// states, represented using 128 -bit vectors, following algorithm described on section 3.2.4 of SHA3
 /// specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///
-/// Every lane is 128 -bit wide, holding two different Keccak-p\[1600\] lanes, each of
-/// width 64 -bits. Lanes are laid out on registers as shown below.
-///
-/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
-///
-/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
-///
-/// \[<-----------u64----------> || <-----------u64-------->\]
-///
-/// \[<-------------------------u64x2---------------------->\]
-///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L209-L227
 #[cfg(feature = "simd")]
 #[inline(always)]
@@ -271,17 +238,6 @@ fn iota(state: &mut [u64; 25], ridx: usize) {
 /// states, represented using 128 -bit vectors, following algorithm described on section 3.2.5 of SHA3
 /// specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///
-/// Every lane is 128 -bit wide, holding two different Keccak-p\[1600\] lanes, each of
-/// width 64 -bits. Lanes are laid out on registers as shown below.
-///
-/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
-///
-/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
-///
-/// \[<-----------u64----------> || <-----------u64-------->\]
-///
-/// \[<-------------------------u64x2---------------------->\]
-///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L229-L235
 #[cfg(feature = "simd")]
 #[inline(always)]
@@ -309,17 +265,6 @@ fn round(state: &mut [u64; 25], ridx: usize) {
 /// states, represented using 128 -bit vectors, applying all five step mapping functions
 /// in order, mutating state array, following algorithm described on section 3.3
 /// of https://dx.doi.org/10.6028/NIST.FIPS.202
-///
-/// Every lane is 128 -bit wide, holding two different Keccak-p\[1600\] lanes, each of
-/// width 64 -bits. Lanes are laid out on registers as shown below.
-///
-/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
-///
-/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
-///
-/// \[<-----------u64----------> || <-----------u64-------->\]
-///
-/// \[<-------------------------u64x2---------------------->\]
 ///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L237-L251
 #[cfg(feature = "simd")]

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -258,6 +258,25 @@ fn iota(state: &mut [u64; 25], ridx: usize) {
     state[0] ^= RC[ridx];
 }
 
+/// Keccak-p\[1600, 12\] step mapping function ι, parallelly applied on two Keccak-p\[1600\]
+/// states, represented using 128 -bit vectors, following algorithm described on section 3.2.5 of SHA3
+/// specification https://dx.doi.org/10.6028/NIST.FIPS.202
+///
+/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
+///
+/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
+///
+/// \[<-----------u64----------> || <-----------u64-------->\]
+///
+/// \[<-------------------------u64x2---------------------->\]
+///
+/// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L229-L235
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn iotax2(state: &mut [u64x2; 25], ridx: usize) {
+    state[0] ^= u64x2::splat(RC[ridx]);
+}
+
 /// Keccak-p\[1600, 12\] round function, which applies all five
 /// step mapping functions in order, mutating state array, following
 /// section 3.3 of https://dx.doi.org/10.6028/NIST.FIPS.202

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -222,6 +222,33 @@ fn chi(istate: &[u64; 25], ostate: &mut [u64; 25]) {
     }
 }
 
+/// Keccak-p\[1600, 12\] step mapping function χ, parallelly applied on two Keccak-p\[1600\]
+/// states, represented using 128 -bit vectors, following algorithm described on section 3.2.4 of SHA3
+/// specification https://dx.doi.org/10.6028/NIST.FIPS.202
+///
+/// \[127, 126, 125, ..., 65, 64 || 63, 62, ..., 3, 2, 1, 0\]
+///
+/// \[<--------state\[1\]--------> || <-------state\[0\]------->\]
+///
+/// \[<-----------u64----------> || <-----------u64-------->\]
+///
+/// \[<-------------------------u64x2---------------------->\]
+///
+/// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L209-L227
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn chix2(istate: &[u64x2; 25], ostate: &mut [u64x2; 25]) {
+    for y in 0..5 {
+        let off = y * 5;
+
+        ostate[off + 0] = istate[off + 0] ^ (!istate[off + 1] & istate[off + 2]);
+        ostate[off + 1] = istate[off + 1] ^ (!istate[off + 2] & istate[off + 3]);
+        ostate[off + 2] = istate[off + 2] ^ (!istate[off + 3] & istate[off + 4]);
+        ostate[off + 3] = istate[off + 3] ^ (!istate[off + 4] & istate[off + 0]);
+        ostate[off + 4] = istate[off + 4] ^ (!istate[off + 0] & istate[off + 1]);
+    }
+}
+
 /// Keccak-p\[1600, 12\] step mapping function ι, see section 3.2.5 of SHA3
 /// specification https://dx.doi.org/10.6028/NIST.FIPS.202
 ///

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -194,7 +194,10 @@ fn rhox2(state: &mut [u64x2; 25]) {
 ///
 /// Adapted from https://github.com/itzmeanjan/sha3/blob/b5e897ed/include/keccak.hpp#L192-L207
 #[inline(always)]
-fn pi(istate: &[u64; 25], ostate: &mut [u64; 25]) {
+fn pi<T>(istate: &[T; 25], ostate: &mut [T; 25])
+where
+    T: Copy,
+{
     unroll! {
         for i in 0..25 {
             ostate[i] = istate[PERM[i]];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(portable_simd)]
+
 #[cfg(feature = "dev")]
 pub mod keccak;
 #[cfg(not(feature = "dev"))]


### PR DESCRIPTION
- [x] Use 128 -bit lanes for representing two Keccak-p[1600, 12] permutation states - defined keccak permutation functions
- [ ] Test functional correctness of 2x SIMD parallel Keccak-p[1600, 12] permutation
- [x] Benchmark new Keccak-p[1600, 12] permutation

```bash
# for benchmarking scalar keccak permutation
RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench keccak --features dev

# for benchmarking SIMD parallel keccak permutation
RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench keccak --features dev,simd
```